### PR TITLE
fix() format int to string without scientific format 2.4*e10

### DIFF
--- a/R/mzMl-functions.R
+++ b/R/mzMl-functions.R
@@ -380,7 +380,7 @@
     for (i in seq(along=accession)) {
       .writeXmlTag("cvParam", intend=6, file=file,
                    attrs=c(cvRef="IMS", accession=accession[i], name=name[i],
-                           value=value[i]))
+                           value=format(value[i], scientific=FALSE)))
     }
     .writeCloseXmlTag("scan", intend=5, file=file)
   .writeCloseXmlTag("scanList", intend=4, file=file)
@@ -410,7 +410,7 @@
     for (i in seq(along=accession)) {
       .writeXmlTag("cvParam", intend=6, file=file,
                    attrs=c(cvRef="IMS", accession=accession[i], name=name[i],
-                           value=value[i]))
+                           value=format(value[i], scientific=FALSE)))
     }
     .writeXmlTag("binary", intend=6, file=file)
   .writeCloseXmlTag("binaryDataArray", intend=5, file=file)


### PR DESCRIPTION
If the Offset of the BinaryData Cross a certain level R create number in "scientific" format (2.5*e5). With such a Value we cannot read the ibd file anymore. I fixed the problem at this point and also at the position (IMS:1000050/51) were such a error can also occure.
My actual promblem ist that I realy don't know how to test this. If I get a hint therefore I would also implemnt a test for this pull request